### PR TITLE
Fix the help for the Cautious mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,2 @@
 test:
-	rm -rf /tmp/_adareducer_test
-	cp -R tests/orig /tmp/_adareducer_test && \
-    gprbuild -P /tmp/_adareducer_test/p.gpr && \
-    python ada_reduce.py --single-file /tmp/_adareducer_test/proc.adb --follow-closure /tmp/_adareducer_test/p.gpr tests/basic.sh
+	bash tests/test.sh

--- a/adareducer/engine.py
+++ b/adareducer/engine.py
@@ -1,5 +1,6 @@
 import subprocess
 import os
+import sys
 import libadalang as lal
 
 from adareducer.types import Buffer
@@ -34,7 +35,16 @@ ATTEMPT_DELETE = True
 
 # In cautious mode, run the predicate after running each file as a sanity check
 CAUTIOUS_MODE = True
+CAUTIOUS_MODE_HELP = """adareducer has found that the predicate no longer applies
+after completing a cycle on one file. This is unexpected.
 
+This may happen when the predicate uses a builder which looks at
+timestamps in order to check whether a file needs rebuilding: if
+the modifications happen faster than the granularity of the
+filesystem timestamps, this will fool this check.
+
+If you are using "gprbuild" in your predicate, make sure to pass "-m2".
+"""
 
 class StrategyStats(object):
     def __init__(self, characters_removed, time):
@@ -330,7 +340,8 @@ class Reducer(object):
 
         if CAUTIOUS_MODE:
             if not self.run_predicate():
-                raise ("a fuss")
+                log(CAUTIOUS_MODE_HELP)
+                sys.exit(1)
 
         # Move on to the next files
 

--- a/tests/basic.sh
+++ b/tests/basic.sh
@@ -1,3 +1,3 @@
-cd /tmp/_adareducer_test && \
+cd $ADAREDUCER_TEMP_DIR && \
 gprbuild -m2 -q -Pp.gpr && \
 ./proc | grep "hello"

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,12 @@
+set -e 
+
+export ADAREDUCER_TEMP_DIR=` mktemp -d` 
+
+trap \
+ "{ rm -rf "${ADAREDUCER_TEMP_DIR}" ; exit 255; }" \
+ SIGINT SIGTERM ERR EXIT
+
+cp -R tests/orig/* $ADAREDUCER_TEMP_DIR
+gprbuild -P $ADAREDUCER_TEMP_DIR/p.gpr
+python adareducer.py --single-file $ADAREDUCER_TEMP_DIR/proc.adb --follow-closure $ADAREDUCER_TEMP_DIR/p.gpr tests/basic.sh
+rm -rf $ADAREDUCER_TEMP_DIR


### PR DESCRIPTION
When the Cautious mode catches something, print a more helpful
message.

Adapt the Makefile so that it doesn't hard code a temporary directory,
allowing runs by multiple users or concurrent runs by one user.