### PR TITLE
Prevent reduction of sources in "externally built" projects

### DIFF
--- a/ada_reducer/engine.py
+++ b/ada_reducer/engine.py
@@ -48,6 +48,7 @@ filesystem timestamps, this will fool this check.
 If you are using "gprbuild" in your predicate, make sure to pass "-m2".
 """
 
+
 class StrategyStats(object):
     def __init__(self, characters_removed, time):
         self.characters_removed = characters_removed
@@ -86,7 +87,7 @@ class Reducer(object):
 
     def attempt_delete_all(self, files):
         """attempt pretend-deletion of all files in files by appending
-           '.deleted' to the file name
+        '.deleted' to the file name
         """
 
         def pretend_deletion(name):
@@ -114,7 +115,7 @@ class Reducer(object):
 
     def sort_ads_files(self):
         """Sort .ads files into a tree structure, allowing to process
-           the leaf nodes first"""
+        the leaf nodes first"""
 
         ads_dict = {}
         # A dict showing dependencies of als
@@ -258,7 +259,7 @@ class Reducer(object):
     def apply_strategies_on_file(self, file, buf) -> int:
         """Apply all the strategies on the given buf.
 
-           Return the number of characters removed.
+        Return the number of characters removed.
         """
         count = buf.count_chars()
         unit = self.context.get_from_file(file)
@@ -410,12 +411,15 @@ class Reducer(object):
                         # find the definition
                         if decl is not None:
                             file_to_add = decl.unit.filename
-                            if file_to_add.endswith(".ads"):
-                                # if it's a .ads we want to empty, empty
-                                # the .adb first, it will go faster
-                                adb = file_to_add[:-1] + "b"
-                                if os.path.exists(adb):
-                                    self.bodies_to_reduce.append(adb)
-                                self.ads_dict[file_to_add] = []
-                            else:
-                                self.bodies_to_reduce.append(file_to_add)
+
+                            # Only process files that are in the project closure
+                            if self.resolver.belongs_to_project(file_to_add):
+                                if file_to_add.endswith(".ads"):
+                                    # if it's a .ads we want to empty, empty
+                                    # the .adb first, it will go faster
+                                    adb = file_to_add[:-1] + "b"
+                                    if os.path.exists(adb):
+                                        self.bodies_to_reduce.append(adb)
+                                    self.ads_dict[file_to_add] = []
+                                else:
+                                    self.bodies_to_reduce.append(file_to_add)

--- a/ada_reducer/project_support.py
+++ b/ada_reducer/project_support.py
@@ -8,8 +8,13 @@ class ProjectResolver(object):
 
     def __init__(self, project_file):
         self.files = {}
+        # The sources in this project tree, not including externally built
+        # projects.
+        # Keys: base names, values: full names
 
-        # Use the Libadalang API to query the sources for this project
+        # Use the Libadalang API to query the sources for this project.
+        # This collects the sources in all the project tree, not including
+        # sources in externally built projects.
         files = lal.SourceFiles.for_project(project_file)
 
         for full_path in files:
@@ -31,3 +36,10 @@ class ProjectResolver(object):
             print(f"file {basename} not found in project")
             return None
         return self.files[basename]
+
+    def belongs_to_project(self, filename):
+        """Return True iff filename is a source of this project tree,
+        not including externally built projects.
+        """
+        basename = PurePath(filename).name
+        return basename in self.files

--- a/testsuite/tests/externally_built_safety/hello.adb
+++ b/testsuite/tests/externally_built_safety/hello.adb
@@ -1,0 +1,8 @@
+with Ada.Text_IO;
+with A; use A;
+
+procedure Hello is
+begin
+   Foo;
+   Ada.Text_IO.Put_Line ("hello");
+end Hello;

--- a/testsuite/tests/externally_built_safety/oracle.sh
+++ b/testsuite/tests/externally_built_safety/oracle.sh
@@ -1,0 +1,4 @@
+set -e
+set -x
+gprbuild  -m2 -Pp hello
+grep Foo hello.adb

--- a/testsuite/tests/externally_built_safety/p.gpr
+++ b/testsuite/tests/externally_built_safety/p.gpr
@@ -1,0 +1,4 @@
+with "src_q/q";
+
+project p is
+end p;

--- a/testsuite/tests/externally_built_safety/src_q/a.ads
+++ b/testsuite/tests/externally_built_safety/src_q/a.ads
@@ -1,0 +1,7 @@
+package a is
+
+   procedure Foo is null;
+
+   procedure Bar is null;
+
+end a;

--- a/testsuite/tests/externally_built_safety/src_q/q.gpr
+++ b/testsuite/tests/externally_built_safety/src_q/q.gpr
@@ -1,0 +1,6 @@
+project Q is
+  type eb_type is ("true", "false");
+  eb : eb_type := external("EXTERNALLY_BUILT", "false");
+
+  for Externally_Built use eb;
+end Q;

--- a/testsuite/tests/externally_built_safety/test.out
+++ b/testsuite/tests/externally_built_safety/test.out
@@ -1,0 +1,3 @@
+package a is
+   procedure Foo is null;
+end a;

--- a/testsuite/tests/externally_built_safety/test.sh
+++ b/testsuite/tests/externally_built_safety/test.sh
@@ -1,0 +1,20 @@
+set -e
+
+# Build the external project once
+gprbuild -q -P src_q/q.gpr -XEXTERNALLY_BUILT=false
+
+cp src_q/a.ads src_q/a.ads.orig
+# Try reducing a project that imports an externally built project
+export EXTERNALLY_BUILT=true
+$ADAREDUCER --single-file hello.adb --follow-closure p.gpr oracle.sh > /dev/null
+
+# We should not have touched a.ads
+diff -c src_q/a.ads.orig src_q/a.ads
+
+# Now try reducing a project that imports the same project,
+# this time it's not externally built
+export EXTERNALLY_BUILT=false
+$ADAREDUCER --single-file hello.adb --follow-closure p.gpr oracle.sh > /dev/null
+
+# We should have processed a.ads: cat it, the driver will compare it to test.out
+cat src_q/a.ads

--- a/testsuite/tests/externally_built_safety/test.yaml
+++ b/testsuite/tests/externally_built_safety/test.yaml
@@ -1,0 +1,1 @@
+description: "externally_built_safety"


### PR DESCRIPTION
This tests that subprojects declared as externally built do not get processed by adareducer.