### PR TITLE
Fix issue with brute force removals

### DIFF
--- a/ada_reducer/engine.py
+++ b/ada_reducer/engine.py
@@ -125,7 +125,7 @@ class Reducer(object):
         # First, add them all
         for x in self.resolver.files:
             full = self.resolver.files[x]
-            if full.endswith(".ads"):
+            if full.endswith(".ads") and os.path.exists(full):
                 ads_dict[full] = set()
 
         # Now iterate on all of them
@@ -226,6 +226,7 @@ class Reducer(object):
         # reduction: this might save time by deleting files we would have tried
         # to reduce.
         if BRUTEFORCE_DELETE:
+            log("=> Removing any unused files")
             self.attempt_delete_all(
                 [self.resolver.files[name] for name in self.resolver.files]
             )

--- a/testsuite/tests/deletion_leftover/a.ads
+++ b/testsuite/tests/deletion_leftover/a.ads
@@ -1,0 +1,2 @@
+package a is
+end a;

--- a/testsuite/tests/deletion_leftover/hello.adb
+++ b/testsuite/tests/deletion_leftover/hello.adb
@@ -1,0 +1,5 @@
+with Ada.Text_IO;
+procedure Hello is
+begin
+   Ada.Text_IO.Put_Line ("hello");
+end Hello;

--- a/testsuite/tests/deletion_leftover/oracle.sh
+++ b/testsuite/tests/deletion_leftover/oracle.sh
@@ -1,0 +1,1 @@
+gcc -c hello.adb

--- a/testsuite/tests/deletion_leftover/p.gpr
+++ b/testsuite/tests/deletion_leftover/p.gpr
@@ -1,0 +1,2 @@
+project p is
+end p;

--- a/testsuite/tests/deletion_leftover/test.out
+++ b/testsuite/tests/deletion_leftover/test.out
@@ -1,0 +1,1 @@
+world.adb.deleted

--- a/testsuite/tests/deletion_leftover/test.sh
+++ b/testsuite/tests/deletion_leftover/test.sh
@@ -1,0 +1,6 @@
+# This tests against a case where
+#  - we're brute-force deleting a.ads
+#  - adareducer would crash when trying to process it
+#    after it's been deleted
+$ADAREDUCER p.gpr oracle.sh > /dev/null
+ls | grep world

--- a/testsuite/tests/deletion_leftover/test.yaml
+++ b/testsuite/tests/deletion_leftover/test.yaml
@@ -1,0 +1,1 @@
+description: "deletion_leftover"

--- a/testsuite/tests/deletion_leftover/world.adb
+++ b/testsuite/tests/deletion_leftover/world.adb
@@ -1,0 +1,5 @@
+with Ada.Text_IO;
+procedure Hello is
+begin
+   Ada.Text_IO.Put_Line ("world");
+end Hello;


### PR DESCRIPTION
There could be a case where the brute force removal is successful
in getting rid of a file, but the engine still tries to read this
file from disk later. Add defensive programming against this and
add a test.

Fixes #27